### PR TITLE
add userId to authorize function return

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ License information
 
 This project is released under the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).
 
+API
+---
+1. Client side:
+   - createPasswordHash = function(password: String, userId: String)
+
+   - createRequest = function(path: String, userId: String, passwordHash: String, timestamp: String)
+
+2. Server side:
+   - authorize = function(loadUser: Function, token: String)
+
+   - authenticate = function(loadUser: Function, createRequest: Function, createToken: Function, request: Object) 
+
 Changelog
 ---------
 

--- a/authorize.js
+++ b/authorize.js
@@ -51,6 +51,7 @@ define([
         if (!user.hasOwnProperty("sessionKey") || !isString(user.sessionKey) || isEmpty(user.sessionKey) ||
             !user.hasOwnProperty("sessionDurationMinutes") || !isInteger(user.sessionDurationMinutes) ||
             !user.hasOwnProperty("sessionStartTime") || !isString(user.sessionStartTime) || isEmpty(user.sessionStartTime) ||
+            !user.hasOwnProperty("id") || !isString(user.id) || isEmpty(user.id) ||
                 !user.hasOwnProperty("roles") || !isArray(user.roles)) {
             return {
                 error: authErrors.INVALID_USER_LOADED,
@@ -67,6 +68,9 @@ define([
             };
         }
         // return roles
-        return user.roles;
+        return {
+            id: user.id,
+            roles: user.roles
+        };
     };
 });

--- a/authorize.js
+++ b/authorize.js
@@ -36,7 +36,7 @@ define([
 
         // check token well-formed
         if (!isObject(token) || 
-            !token.hasOwnProperty("sessionKey") || !isString(user.sessionStartTime) || isEmpty(token.sessionKey)) {
+            !token.hasOwnProperty("sessionKey") || !isString(token.sessionKey) || isEmpty(token.sessionKey)) {
             return {
                 error: authErrors.TOKEN_NOT_WELL_FORMED
             };

--- a/authorize.js
+++ b/authorize.js
@@ -35,7 +35,8 @@ define([
         }
 
         // check token well-formed
-        if (!isObject(token) || !token.hasOwnProperty("sessionKey") || isEmpty(token.sessionKey)) {
+        if (!isObject(token) || 
+            !token.hasOwnProperty("sessionKey") || !isString(user.sessionStartTime) || isEmpty(token.sessionKey)) {
             return {
                 error: authErrors.TOKEN_NOT_WELL_FORMED
             };
@@ -48,11 +49,11 @@ define([
                 error: authErrors.INVALID_TOKEN_HASH
             };
         }
-        if (!user.hasOwnProperty("sessionKey") || !isString(user.sessionKey) || isEmpty(user.sessionKey) ||
-            !user.hasOwnProperty("sessionDurationMinutes") || !isInteger(user.sessionDurationMinutes) ||
+        if (!user.hasOwnProperty("sessionDurationMinutes") || !isInteger(user.sessionDurationMinutes) ||
             !user.hasOwnProperty("sessionStartTime") || !isString(user.sessionStartTime) || isEmpty(user.sessionStartTime) ||
             !user.hasOwnProperty("id") || !isString(user.id) || isEmpty(user.id) ||
-                !user.hasOwnProperty("roles") || !isArray(user.roles)) {
+            !user.hasOwnProperty("role") || !isString(user.role) || isEmpty(user.role) ||
+                !user.hasOwnProperty("rights") || !isArray(user.rights)) {
             return {
                 error: authErrors.INVALID_USER_LOADED,
                 user: user
@@ -70,7 +71,8 @@ define([
         // return roles
         return {
             id: user.id,
-            roles: user.roles
+            role: user.role,
+            rights: user.rights
         };
     };
 });

--- a/test.js
+++ b/test.js
@@ -49,7 +49,8 @@ define([
         sessionKey: undefined,
         sessionStartTime: undefined,
         sessionDurationMinutes: 30,
-        roles: ["foo1", "bar1"]
+        role: "admin",
+        rights: ["foo1", "bar1"]
     };
 
     function createToken(user, request) {
@@ -106,9 +107,10 @@ define([
     var user = myAuthorize(token);
 
     assert(isString(user.id));
-    assert(isArray(user.roles));
+    assert(isString(user.role));
+    assert(isArray(user.rights));
     assert(isNil(user.error));
-    assert.equal(user.roles.length, 2);
+    assert.equal(user.rights.length, 2);
 
 
     // test authenticate error messages


### PR DESCRIPTION
Calling the authorization function on the server, we want to put both the roles and userId in the headers as a result. I think that getting them immediately is more more convenient.
renamed test.js user -> userInDB to better reflect its essence and avoid confusion.